### PR TITLE
API for schema dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-release
 
 
 before_install:

--- a/addon/models/document-object.js
+++ b/addon/models/document-object.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  _attrs: {},
+  serialize() {
+    let newAttrs = {};
+    let excludeMatch = /^_/ig;
+
+    for (let key in this) {
+      if (this.hasOwnProperty(key) && !excludeMatch.test(key)) {
+        let val = this[key];
+
+        if (typeof val.serialize === 'function') {
+          val = val.serialize();
+        }
+
+        newAttrs[key] = val;
+      }
+    }
+
+    this._attrs = newAttrs;
+    return this._attrs;
+  }
+});

--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -28,7 +28,7 @@ export default class Document {
   }
 
   dump() {
-    return this._values;
+    return this._values.serialize();
   }
 
   load() {
@@ -73,11 +73,15 @@ export class ArrayDocument extends Document {
   }
 
   dump(params = {}) {
+    let values = this._values;
+
     if (params.excludeInvalid) {
-      return this.validValues();
-    } else {
-      return this._values;
+      values = this.validValues();
     }
+
+    return values.map((item) => {
+      return item.serialize();
+    });
   }
 
   validValues() {
@@ -174,8 +178,11 @@ export class ObjectDocument extends Document {
       throw new Error('You must provide a value as the second argument to `.set`');
     }
 
-    let proxy = this._valueProxyFor(propertyPath);
-    proxy.value = value;
+    Ember.run(() => {
+      let proxy = this._valueProxyFor(propertyPath);
+      proxy.value = value;
+      this.values.notifyPropertyChange(propertyPath);
+    });
   }
 
   get(propertyPath) {

--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -3,13 +3,19 @@ import buildDefaultValueForType from '../utils/build-default-value-for-type';
 import checkValidity from '../utils/check-validity';
 
 export default class Property {
-  constructor(property, schemaStack) {
+  constructor(property, _parentProperty, _key, _schemaStack) {
     if (!property) {
-      throw new Error('You must provide a property definition to the Property constructor.');
+      throw new Error('You must provide a property definition to the `Property` constructor.');
     }
 
+    if (_parentProperty && !_key) {
+      throw new Error('You must provide a property `key` to the `Property` constructor when a `parentProperty` exists.');
+    }
+
+    this._key = _key;
     this._property = property;
-    this._schemaStack = schemaStack;
+    this._parentProperty = _parentProperty;
+    this._schemaStack = _schemaStack;
   }
 
   get type() {
@@ -44,6 +50,10 @@ export default class Property {
     return null;
   }
 
+  getChildProperty(key) {
+    return this.properties[key];
+  }
+
   resolveURI(uri) {
     let hashIdx = uri.indexOf('#');
 
@@ -72,6 +82,66 @@ export default class Property {
 
   get required() {
     return this._property.required || [];
+  }
+
+  get dependencies() {
+    return this._property.dependencies || {};
+  }
+
+  get parentProperty() {
+    return this._parentProperty;
+  }
+
+  get hasParentProperty() {
+    return !!this._parentProperty;
+  }
+
+  get key() {
+    return this._key;
+  }
+
+  get isDependentProperty() {
+    return this.dependsOnProperties.length > 0;
+  }
+
+  get hasDependentProperties() {
+    return this.dependentProperties.length > 0;
+  }
+
+  get dependsOnProperties() {
+    let myKey = this.key;
+    let dependsOn = [];
+
+    if (this.hasParentProperty) {
+      let siblingDependencies = this.parentProperty.dependencies;
+
+      for (let key in siblingDependencies) {
+        if (siblingDependencies[key].indexOf(myKey) > -1) {
+          dependsOn.push(this.parentProperty.getChildProperty(key));
+        }
+      }
+    }
+
+    return dependsOn;
+  }
+
+  get dependentProperties() {
+    let myKey = this.key;
+    let dependents = [];
+
+    if (this.hasParentProperty) {
+      let siblingDependencies = this.parentProperty.dependencies;
+
+      Object.keys(siblingDependencies).forEach((key) => {
+        if (key === myKey) {
+          siblingDependencies[key].forEach((key) => {
+            dependents.push(this.parentProperty.getChildProperty(key));
+          });
+        }
+      });
+    }
+
+    return dependents;
   }
 
   get schemaStack() {

--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -144,6 +144,18 @@ export default class Property {
     return dependents;
   }
 
+  get documentPath() {
+    if (this.hasParentProperty) {
+      if (this.parentProperty.documentPath) {
+        return [this.parentProperty.documentPath, this.key].join('.');
+      } else {
+        return this.key;
+      }
+    }
+
+    return '';
+  }
+
   get schemaStack() {
     return this._schemaStack;
   }

--- a/addon/models/value-proxy.js
+++ b/addon/models/value-proxy.js
@@ -51,7 +51,7 @@ class ValueProxy {
       this.value = this._property.buildDefaultValue();
     }
 
-    return this._values[this._valuePath];
+    return Ember.get(this._values, this._valuePath);
   }
 }
 

--- a/addon/utils/build-default-value-for-type.js
+++ b/addon/utils/build-default-value-for-type.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import DocumentObject from '../models/document-object';
 
 export default function buildDefaultValueForType(type) {
   switch (type) {
-  case 'object': return Object.create(null);
+  case 'object': return DocumentObject.create({});
   case 'array': return Ember.A();
   default:
     return undefined;

--- a/addon/utils/get-properties.js
+++ b/addon/utils/get-properties.js
@@ -18,7 +18,8 @@ export default function(object, rawProperties) {
         rawProperty = object.resolveURI(rawProperty.$ref);
       }
 
-      properties[key] = new Property(rawProperty, object.schemaStack);
+      properties[key] = new Property(rawProperty, object, key,
+                                     object.schemaStack);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-json-schema-document",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "An ember-cli addon for building and validating JSON Schema documents",
   "directories": {
     "test": "tests"

--- a/tests/integration/models/document-observability-test.js
+++ b/tests/integration/models/document-observability-test.js
@@ -29,6 +29,7 @@ test('can observe document properties', function(assert) {
 });
 
 test('can observe array based document properties', function(assert) {
+
   this.schema = new Schema(arrayBaseObjectFixture);
   this.document = this.schema.buildDocument();
 

--- a/tests/unit/models/array-document-test.js
+++ b/tests/unit/models/array-document-test.js
@@ -101,6 +101,7 @@ test('can remove an item by index from an array based document', function(assert
 
   this.document.removeItem(1);
 
+  result = this.document.dump();
   assert.deepEqual(result, [expected1]);
 });
 
@@ -119,7 +120,7 @@ test('can remove an item by reference from an array based document', function(as
   assert.deepEqual(result, [expected1, expected2]);
 
   this.document.removeObject(item1);
-
+  result = this.document.dump();
   assert.deepEqual(result, [expected2]);
 });
 

--- a/tests/unit/models/property-dependency-test.js
+++ b/tests/unit/models/property-dependency-test.js
@@ -1,0 +1,124 @@
+import Property from 'ember-json-schema-document/models/property';
+
+import { module, test } from 'qunit';
+
+export const orderFixture = {
+  'id': 'http://jsonschema.net/order',
+  'type': 'object',
+  'properties': {
+    'name': { 'type': 'string' },
+    'email': { 'type': 'string' },
+    'shippingAddress': {
+      'type': 'object',
+      'dependencies': {
+        'useAlternateShippingAddress': ['streetAddress', 'city', 'state']
+      },
+      'required': ['useAlternateShippingAddress'],
+      'properties': {
+        'useAlternateShippingAddress': {
+          'type': 'boolean'
+        },
+        'streetAddress': {
+          'id': 'http://jsonschema.net/address/streetAddress',
+          'type': 'string'
+        },
+        'city': {
+          'id': 'http://jsonschema.net/address/city',
+          'type': 'string'
+        },
+        'state': {
+          'id': 'http://jsonschema.net/address/city',
+          'type': 'string',
+          'enum': ['NY', 'IN']
+        }
+      }
+    },
+
+    'billingAddress': {
+      'type': 'object',
+      'properties': {
+        'streetAddress': {
+          'id': 'http://jsonschema.net/address/streetAddress',
+          'type': 'string'
+        },
+        'city': {
+          'id': 'http://jsonschema.net/address/city',
+          'type': 'string'
+        },
+        'state': {
+          'id': 'http://jsonschema.net/address/city',
+          'type': 'string',
+          'enum': ['NY', 'IN']
+        }
+      },
+      'required': [ 'streetAddress','city', 'state' ]
+    }
+  }
+};
+
+let property;
+module('models/property', {
+  beforeEach() {
+    property = new Property(orderFixture);
+  }
+});
+
+test('`dependencies` returns hash of property dependencies', function(assert) {
+  let expectedDependencies = {
+    useAlternateShippingAddress: ['streetAddress', 'city', 'state']
+  };
+
+  assert.deepEqual(property.dependencies, {}, 'root object has no dependencies');
+  assert.deepEqual(property.getChildProperty('shippingAddress').dependencies,
+                   expectedDependencies, 'shipping address has dependencies');
+});
+
+test('`parentProperty` returns property\'s parent property', function(assert) {
+  assert.deepEqual(property.parentProperty, undefined, 'root has no parent property');
+  assert.deepEqual(property.getChildProperty('shippingAddress').parentProperty,
+                   property, 'shipping address `parentProperty` is root property');
+});
+
+test('`hasParentProperty` returns true for non-root property', function(assert) {
+  assert.equal(property.hasParentProperty, false, 'root has no parent property');
+  assert.equal(property.getChildProperty('shippingAddress').hasParentProperty,
+                   true, 'shipping address has a parent property');
+});
+
+test('`key` returns property key', function(assert) {
+  let childProp = property.getChildProperty('shippingAddress');
+  let grandChildProp = childProp.getChildProperty('city');
+  assert.equal(property.key, undefined, 'root property has no key');
+  assert.equal(childProp.key, 'shippingAddress', 'returns correct key');
+  assert.equal(grandChildProp.key, 'city', 'returns correct key');
+});
+
+test('`dependsOnProperties` returns the properties that depend on this property', function(assert) {
+  let child = property.getChildProperty('shippingAddress');
+  let master = child.getChildProperty('useAlternateShippingAddress');
+  let dependent = child.getChildProperty('city');
+
+  assert.deepEqual(dependent.dependsOnProperties, [master], 'master is included in dependsOnProperties list');
+});
+
+test('`isDependentProperty` returns true for properties that depend on other properties', function(assert) {
+  let child = property.getChildProperty('shippingAddress');
+  let dependent = child.getChildProperty('city');
+
+  assert.equal(dependent.isDependentProperty, true, 'returns true when property depends on another property');
+});
+
+test('`dependentProperties` returns properties that depend on this property', function(assert) {
+  let child = property.getChildProperty('shippingAddress');
+  let master = child.getChildProperty('useAlternateShippingAddress');
+  let dependents = [child.getChildProperty('streetAddress'), child.getChildProperty('city'),
+                    child.getChildProperty('state')];
+  assert.deepEqual(master.dependentProperties, dependents, 'includes dependent properties');
+});
+
+test('`hasDependentProperties` returns true if properties depend on this property', function(assert) {
+  let child = property.getChildProperty('shippingAddress');
+  let master = child.getChildProperty('useAlternateShippingAddress');
+
+  assert.equal(master.hasDependentProperties, true, 'is true when dependent properties exist');
+});

--- a/tests/unit/models/property-dependency-test.js
+++ b/tests/unit/models/property-dependency-test.js
@@ -122,3 +122,11 @@ test('`hasDependentProperties` returns true if properties depend on this propert
 
   assert.equal(master.hasDependentProperties, true, 'is true when dependent properties exist');
 });
+
+test('`documentPath` returns the full property path', function(assert) {
+  let child = property.getChildProperty('shippingAddress');
+  let grandChild = child.getChildProperty('city');
+
+  assert.equal(child.documentPath, 'shippingAddress', 'first level');
+  assert.equal(grandChild.documentPath, 'shippingAddress.city', 'nth level');
+});

--- a/tests/unit/models/property-test.js
+++ b/tests/unit/models/property-test.js
@@ -69,7 +69,7 @@ test('accessing properties returns an instance of `Property` model', function(as
 });
 
 test('can create a default value for an object', function(assert) {
-  assert.deepEqual(property.buildDefaultValue(), {}, 'defaultValue returns an object if property type is object');
+  assert.deepEqual(property.buildDefaultValue().serialize(), {}, 'defaultValue returns an object if property type is object');
 });
 
 test('can create a default value for an object', function(assert) {

--- a/tests/unit/models/property-test.js
+++ b/tests/unit/models/property-test.js
@@ -41,13 +41,23 @@ test('accepts a property definition to constructor', function(assert) {
 test('throws an error if schema is not provided to constructor', function(assert) {
   assert.throws(function() {
     new Property();
-  }, /You must provide a property definition to the Property constructor./);
+  }, /You must provide a property definition to the `Property` constructor./);
+});
+
+test('throws an error if parent property is supplised without a key', function(assert) {
+  assert.throws(function() {
+    new Property({ type: 'object', properties: {} }, { type: 'object' });
+  }, /You must provide a property `key` to the `Property` constructor when a `parentProperty` exists./);
 });
 
 test('accessing properties returns a list of properties', function(assert) {
   let propertyKeys = Object.keys(property.properties);
 
   assert.deepEqual(['streetAddress', 'city', 'state'], propertyKeys, 'known keys are present');
+});
+
+test('`getChildProperty` return child property by key', function(assert) {
+  assert.deepEqual(property.getChildProperty('state').validValues, ['NY', 'IN'], 'correct property is returned');
 });
 
 test('accessing properties returns an instance of `Property` model', function(assert) {


### PR DESCRIPTION
This PR adds a convenient set of functions for interacting with schema dependencies.  This changes the signature for `Property`, so expect issues if you are instantiating your own `Property` instances with an optional `schemaStack`.

This API will allow `ember-json-schema-views` to mutate the UI based off the presence or absence of dependent properties.

fixes #44 with https://github.com/aptible/ember-json-schema-views/pull/2