### PR TITLE
Recursively serialize nested objects, removing and undefined values

### DIFF
--- a/addon/models/document-object.js
+++ b/addon/models/document-object.js
@@ -3,22 +3,33 @@ import Ember from 'ember';
 export default Ember.Object.extend({
   _attrs: {},
   serialize() {
+    this._attrs = this.serializeHash(this);
+    return this._attrs;
+  },
+
+  serializeHash(hash) {
     let newAttrs = {};
     let excludeMatch = /^_/ig;
 
-    for (let key in this) {
-      if (this.hasOwnProperty(key) && !excludeMatch.test(key)) {
-        let val = this[key];
+    for (let key in hash) {
+      if (hash.hasOwnProperty(key) && !excludeMatch.test(key)) {
+        let val = hash[key];
 
-        if (typeof val.serialize === 'function') {
+        if (typeof val === 'undefined' || val === null) {
+          continue;
+        }
+
+        if (Array.isArray(val)) {
+          val = val;
+        } else if (typeof val === 'object') {
+          val = this.serializeHash(val);
+        } else if (typeof val.serialize === 'function') {
           val = val.serialize();
         }
 
         newAttrs[key] = val;
       }
     }
-
-    this._attrs = newAttrs;
-    return this._attrs;
+    return newAttrs;
   }
 });

--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -156,9 +156,11 @@ export class ObjectDocument extends Document {
     let properties = Object.keys(data);
     for (let i = 0, l = properties.length; i < l; i++) {
       let propertyName = properties[i];
-
-      this.set(propertyName, data[propertyName]);
+      let proxy = this._valueProxyFor(propertyName);
+      proxy.value = data[propertyName];
     }
+
+    this._values.notifyPropertyChange('didLoad');
   }
 
   _valueProxyFor(path) {

--- a/tests/unit/models/document-test.js
+++ b/tests/unit/models/document-test.js
@@ -40,6 +40,14 @@ test('dump and toJSON return equal values', function(assert) {
   assert.deepEqual(toJSONResult, dumpResult);
 });
 
+test('serialize skips null and undefined values', function(assert) {
+  this.document.set('address.streetAddress', null);
+  this.document.set('address.city', 'San Diego');
+
+  let dumpResult = this.document.dump();
+  assert.deepEqual(dumpResult, { address: { city: 'San Diego' } });
+});
+
 skip('throw an error if calling `dump` when required fields are not specified');
 skip('handle array properties (where you have many of a given item)');
 skip('add validations when setting property types');


### PR DESCRIPTION
Properties with `null` or `undefined` values will now be excluded from `document.dump()`