### PR TITLE
trigger a global property change for easy change notifications

### DIFF
--- a/addon/models/document-object.js
+++ b/addon/models/document-object.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Object.extend({
-  _attrs: {},
   serialize() {
-    this._attrs = this.serializeHash(this);
-    return this._attrs;
+    return this.serializeHash(this);
   },
 
   serializeHash(hash) {

--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -146,6 +146,7 @@ export class ObjectDocument extends Document {
     super(...arguments);
 
     this._valueProxies = Object.create(null);
+    this._propertyUpdate = 0;
 
     if (data) {
       this.load(data);
@@ -180,11 +181,16 @@ export class ObjectDocument extends Document {
       throw new Error('You must provide a value as the second argument to `.set`');
     }
 
-    Ember.run(() => {
-      let proxy = this._valueProxyFor(propertyPath);
-      proxy.value = value;
-      this.values.set(propertyPath, value);
-    });
+    let initialValue = this.values.get(propertyPath);
+    let proxy = this._valueProxyFor(propertyPath);
+    proxy.value = value;
+
+    if (initialValue !== value) {
+      Ember.run(() => {
+        this.values.set(propertyPath, value);
+        this.values.set('_propertyUpdate', this._propertyUpdate++);
+      });
+    }
   }
 
   get(propertyPath) {


### PR DESCRIPTION
This change makes it easy for an observer to be notified of any property change on a schema document by observing `_propertyUpdate` attr on the document.  