### PR TITLE
Add getter for property visiblity

### DIFF
--- a/addon/models/property.js
+++ b/addon/models/property.js
@@ -34,6 +34,14 @@ export default class Property {
     return this._property.readonly || false;
   }
 
+  get visible() {
+    if (this._property._visible === false) {
+      return false;
+    }
+
+    return true;
+  }
+
   get title() {
     return this._property.title;
   }

--- a/tests/unit/models/property-test.js
+++ b/tests/unit/models/property-test.js
@@ -165,3 +165,14 @@ test('`readonly` returns false when undefined in schema', function(assert) {
 
   assert.equal(property.readonly, false, '`readonly` returns false when undefined');
 });
+
+test('`visible` returns true by default', function(assert) {
+  property = new Property({ 'type': 'string' });
+  assert.equal(property.visible, true, '`visible` is true by default');
+});
+
+test('`visible` return false when set to false', function(assert) {
+  property = new Property({ 'type': 'string', _visible: false });
+  assert.equal(property.visible, false, '`visible` is false when set');
+});
+


### PR DESCRIPTION
This adds a getter for `property.visibility`.  Visible will default to true unless explicitly false. 