### PR TITLE
Just debug on undefined, dont blow up

### DIFF
--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -178,7 +178,7 @@ export class ObjectDocument extends Document {
 
   set(propertyPath, value) {
     if (value === undefined) {
-      throw new Error('You must provide a value as the second argument to `.set`');
+      Ember.debug(`Passing 'undefined' value for prop ${propertyPath}`);
     }
 
     let initialValue = this.values.get(propertyPath);


### PR DESCRIPTION
ember-json-schema-views needs to be able to set values back to undefined when the prop is no longer required. 